### PR TITLE
Fixed homepage visitor counter to track unique visits only once per user session

### DIFF
--- a/client/popup.js
+++ b/client/popup.js
@@ -8,6 +8,10 @@ window.onload = function() {
     document.getElementById('popup-nl').style.display = 'none';
   });
 
+  if (localStorage.getItem("noThanksClicked") === "true") {
+    document.getElementById('popup-nl').style.visibility = 'hidden';
+  }
+
   // // Close the pop-up when clicking outside the pop-up content
   // window.addEventListener('click', function(event) {
   //   const popupContent = document.querySelector('.popup-content'); // Select the popup content
@@ -31,4 +35,5 @@ window.onload = function() {
   document.querySelector('.no-thanks-nl').addEventListener('click', function(event) {
     event.preventDefault();
     document.getElementById('popup-nl').style.display = 'none';
+    localStorage.setItem("noThanksClicked", "true");
   });

--- a/client/src/component/Footer.jsx
+++ b/client/src/component/Footer.jsx
@@ -148,7 +148,7 @@ const Footer = (props) => {
                                 <span className="font-bold text-2xl">Total Visitors : </span>
                                 <a href="https://github.com/Anuj3553/Bitbox" target="_blank" rel="noopener noreferrer">
                                     <img
-                                        src="https://hitwebcounter.com/counter/counter.php?page=17062113&style=0006&nbdigits=5&type=page&initCount=1000"
+                                        src="https://hitwebcounter.com/counter/counter.php?page=17062113&style=0006&nbdigits=5&type=ip&initCount=1000"
                                         alt="Visit counter for websites"
                                         className="inline-block"
                                     />


### PR DESCRIPTION
#Title : Fixed homepage visitor counter to track unique visits only once per user session

Fix #359 

## Description
This PR addresses the issue where the visitor count increments each time a user returns to the homepage, even if they have already been counted. The visitor count now only increments on the first visit per user session, ensuring each visitor is counted only once.

@Anuj3553 Pls assign me this issue, give me labels, level.