### PR TITLE
Fix "About US" Page Hidden Behind Navbar

### DIFF
--- a/client/src/component/About.jsx
+++ b/client/src/component/About.jsx
@@ -30,7 +30,7 @@ export default function About(props) {
   // }, []); // Empty dependency array ensures this effect runs only once when component mounts
 
   return (
-    <div>
+    <div className="mt-14">
       {/* About Main Section */}
       <div
         className="about-content container mx-auto px-4 py-16 h-auto min-h-[100vh]"


### PR DESCRIPTION
This PR addresses an issue where the "About Us" page was partially hidden behind the navbar. The position adjustment ensures that the section is fully visible and aligned correctly on the page.

**Issue No.:**

Close #380 
---

# Screenshots/Video (mandatory)
<img width="1229" alt="Screenshot 2024-11-06 at 9 58 24 AM" src="https://github.com/user-attachments/assets/f4529b4b-283c-4c79-82a1-f37cf8d83670">

---

# Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have created a helpful and easy-to-understand `README.md` if it's a new page/tech stack.
- [x] I have gone through the `contributing.md` file before contributing.

**Additional context (Mandatory):**

- [x] I'm a GSSOC-EXT contributor
- [ ] I'm a HACKTOBERFEST contributor
